### PR TITLE
Use Decal tile mode as default for ShaderBuilder

### DIFF
--- a/src/Drawie.Backend.Core/Bridge/Operations/IImageImplementation.cs
+++ b/src/Drawie.Backend.Core/Bridge/Operations/IImageImplementation.cs
@@ -28,6 +28,7 @@ namespace Drawie.Backend.Core.Bridge.Operations
         public Shader ToShader(IntPtr objectPointer, TileMode tileX, TileMode tileY, SamplingOptions samplingOptions,
             Matrix3X3 localMatrix);
         public Shader ToRawShader(IntPtr objectPointer);
+        public Shader ToRawShader(IntPtr objectPointer, TileMode tileX, TileMode tileY);
         public Shader? ToShader(IntPtr objectPointer, TileMode clamp, TileMode tileMode, Matrix3X3 fillMatrixValue);
     }
 }

--- a/src/Drawie.Backend.Core/Shaders/Generation/ShaderBuilder.cs
+++ b/src/Drawie.Backend.Core/Shaders/Generation/ShaderBuilder.cs
@@ -74,7 +74,7 @@ public class ShaderBuilder
         string name = $"texture_{GetUniqueNameNumber()}";
         using var snapshot = surface.Snapshot();
         Uniforms[name] = new Uniform(name,
-            sampleMode == ColorSampleMode.ColorManaged ? snapshot.ToShader() : snapshot.ToRawShader());
+            sampleMode == ColorSampleMode.ColorManaged ? snapshot.ToShader(TileMode.Decal, TileMode.Decal, Matrix3X3.Identity) : snapshot.ToRawShader(TileMode.Decal, TileMode.Decal));
         var newSampler = new SurfaceSampler(name, sampleMode);
         _samplers[surface] = newSampler;
 

--- a/src/Drawie.Backend.Core/Surfaces/ImageData/Image.cs
+++ b/src/Drawie.Backend.Core/Surfaces/ImageData/Image.cs
@@ -96,6 +96,11 @@ namespace Drawie.Backend.Core.Surfaces.ImageData
             return DrawingBackendApi.Current.ImageImplementation.ToRawShader(ObjectPointer);
         }
 
+        public Shader ToRawShader(TileMode tileX, TileMode tileY)
+        {
+            return DrawingBackendApi.Current.ImageImplementation.ToRawShader(ObjectPointer, tileX, tileY);
+        }
+
         public Shader? ToShader(TileMode clamp, TileMode tileMode, Matrix3X3 fillMatrixValue)
         {
             return DrawingBackendApi.Current.ImageImplementation.ToShader(ObjectPointer, clamp, tileMode, fillMatrixValue);

--- a/src/Drawie.Backend.Skia/Implementations/SkiaImageImplementation.cs
+++ b/src/Drawie.Backend.Skia/Implementations/SkiaImageImplementation.cs
@@ -192,6 +192,13 @@ namespace Drawie.Skia.Implementations
             return new Shader(shader.Handle);
         }
 
+        public Shader ToRawShader(IntPtr objectPointer, TileMode tileX, TileMode tileY)
+        {
+            var shader = this[objectPointer].ToRawShader((SKShaderTileMode)tileX, (SKShaderTileMode)tileY);
+            shaderImpl.AddManagedInstance(shader);
+            return new Shader(shader.Handle);
+        }
+
         public Shader? ToShader(IntPtr objectPointer, TileMode clamp, TileMode tileMode, Matrix3X3 fillMatrixValue)
         {
             var shader = this[objectPointer].ToShader((SKShaderTileMode)clamp, (SKShaderTileMode)tileMode,


### PR DESCRIPTION
More pleasant than Clamp, which extends pixel on the edge